### PR TITLE
remove global IORing actor; this should improve performance

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -93,6 +93,8 @@ let package = Package(
       ],
       swiftSettings: [
         .enableExperimentalFeature("StrictConcurrency"),
+        .enableExperimentalFeature("NonisolatedNonsendingByDefault"),
+
       ]
     ),
     .testTarget(

--- a/README.md
+++ b/README.md
@@ -16,9 +16,7 @@ The intention is that this will also eventually support the real-time I/O subsys
 Architecture
 ------------
 
-IORing operations are isolated to the `IORingActor` global actor.
-
-IORing is generally designed to be used as a singleton (`IORing.shared`), however because of some present API limitations to do with allocating fixed buffers, you may need to allocate separate instances. At present all instances share the same actor context and `io_uring` work queue, so there is no performance benefit to allocating more instances. (This should be considered an implementation detail, however.)
+IORing is generally designed to be used as a singleton (`IORing.shared`), however because of some present API limitations to do with allocating fixed buffers, you may need to allocate separate instances.
 
 Public API provides structured concurrency wrappers around common operations such as reading and writing. Multishot APIs, such as `accept(2)`, which can return multiple completions over time return an `AnyAsyncSequence`. Internally, wrappers allocate a concrete instance of `Submission<T>`, representing an initialized Submission Queue Entry (SQE), which is then submitted to the `io_uring`. Completion handlers are handled by having `libdispatch` monitor an `eventfd(2)` representing available completions. The `user_data` in each queue entry is a block, which executes the `onCompletion(cqe:)` method of the `Submission<T>` instance in the ring's isolated context. Care must be taken to manager pointer lifetimes across the event lifecycle.
 

--- a/Sources/IORing/SubmissionGroup.swift
+++ b/Sources/IORing/SubmissionGroup.swift
@@ -57,7 +57,7 @@ actor SubmissionGroup<T: Sendable> {
   func enqueue(submission: SingleshotSubmission<T>) {
     submissions.append(submission)
     Task(on: queue) { _ in
-      await submission.enqueue()
+      submission.enqueue()
     }
   }
 

--- a/Sources/IORingUtils/Socket.swift
+++ b/Sources/IORingUtils/Socket.swift
@@ -295,17 +295,15 @@ public struct Socket: CustomStringConvertible, Equatable, Hashable, Sendable {
     }
   }
 
-  @IORingActor
   public func accept() async throws -> Socket {
     guard let fileHandle else { throw Errno.badFileDescriptor }
     let clientFileHandle: FileDescriptorRepresentable = try await ring.accept(from: fileHandle)
     return Socket(ring: ring, fileHandle: clientFileHandle as! FileHandle)
   }
 
-  @IORingActor
   public func accept() async throws -> AnyAsyncSequence<Socket> {
     guard let fileHandle else { throw Errno.badFileDescriptor }
-    return try ring.accept(from: fileHandle).map { Socket(
+    return try await ring.accept(from: fileHandle).map { Socket(
       ring: ring,
       fileHandle: $0 as! FileHandle
     ) }
@@ -323,20 +321,17 @@ public struct Socket: CustomStringConvertible, Equatable, Hashable, Sendable {
     try fileHandle.setBlocking(true)
   }
 
-  @IORingActor
   public func connect(to address: any SocketAddress) async throws {
     guard let fileHandle else { throw Errno.badFileDescriptor }
     try await ring.connect(fileHandle, to: address)
   }
 
-  @IORingActor
   public func read(into buffer: inout [UInt8], count: Int) async throws -> Int {
     guard let fileHandle else { throw Errno.badFileDescriptor }
 
     return try await ring.read(into: &buffer, count: count, from: fileHandle)
   }
 
-  @IORingActor
   public func read(count: Int, awaitingAllRead: Bool) async throws -> [UInt8] {
     guard let fileHandle else { throw Errno.badFileDescriptor }
 
@@ -353,7 +348,6 @@ public struct Socket: CustomStringConvertible, Equatable, Hashable, Sendable {
     return buffer
   }
 
-  @IORingActor
   public func readFixed(
     count: Int,
     bufferIndex: UInt16,
@@ -380,7 +374,6 @@ public struct Socket: CustomStringConvertible, Equatable, Hashable, Sendable {
     return buffer
   }
 
-  @IORingActor
   public func write(_ buffer: [UInt8], count: Int, awaitingAllWritten: Bool) async throws -> Int {
     guard let fileHandle else { throw Errno.badFileDescriptor }
 
@@ -397,7 +390,6 @@ public struct Socket: CustomStringConvertible, Equatable, Hashable, Sendable {
     return nwritten
   }
 
-  @IORingActor
   public func writeFixed(
     _ buffer: [UInt8],
     bufferIndex: UInt16,
@@ -418,7 +410,6 @@ public struct Socket: CustomStringConvertible, Equatable, Hashable, Sendable {
     return nwritten
   }
 
-  @IORingActor
   public func receive(count: Int) async throws -> [UInt8] {
     guard let fileHandle else { throw Errno.badFileDescriptor }
     return try await ring.receive(
@@ -427,16 +418,14 @@ public struct Socket: CustomStringConvertible, Equatable, Hashable, Sendable {
     )
   }
 
-  @IORingActor
-  public func receive(count: Int) throws -> AnyAsyncSequence<[UInt8]> {
+  public func receive(count: Int) async throws -> AnyAsyncSequence<[UInt8]> {
     guard let fileHandle else { throw Errno.badFileDescriptor }
-    return try ring.receive(
+    return try await ring.receive(
       count: count,
       from: fileHandle
     )
   }
 
-  @IORingActor
   public func send(_ data: [UInt8]) async throws {
     guard let fileHandle else { throw Errno.badFileDescriptor }
     try await ring.send(
@@ -445,7 +434,6 @@ public struct Socket: CustomStringConvertible, Equatable, Hashable, Sendable {
     )
   }
 
-  @IORingActor
   public func receiveMessages(count: Int) async throws -> AnyAsyncSequence<Message> {
     guard let fileHandle else { throw Errno.badFileDescriptor }
     return try await ring.receiveMessages(
@@ -454,7 +442,6 @@ public struct Socket: CustomStringConvertible, Equatable, Hashable, Sendable {
     )
   }
 
-  @IORingActor
   public func sendMessage(_ message: Message) async throws {
     guard let fileHandle else { throw Errno.badFileDescriptor }
     try await ring.send(


### PR DESCRIPTION
use NonisolatedNonsendingByDefault, assumingIsolated() and isolated parameters to ensure that the IORing actor is always used by helper classes.