### PR TITLE
Re-arm multishot recv on ENOBUFS instead of terminating the stream

### DIFF
--- a/Sources/IORing/Submission.swift
+++ b/Sources/IORing/Submission.swift
@@ -524,6 +524,13 @@ final class MultishotSubmission<T: Sendable>: Submission<T>, @unchecked Sendable
           Task { await resubmit(ring: ring) }
         }
       }
+    } catch let error as Errno where error == .noBufferSpace {
+      // provided-buffer pool momentarily exhausted: re-arm after in-flight
+      // buffers are reprovided rather than ending the stream (drops overflow)
+      Task {
+        try? await Task.sleep(nanoseconds: 10_000_000)
+        await resubmit(ring: ring)
+      }
     } catch {
       holder.continuation.finish(throwing: error)
     }

--- a/Tests/IORingTests/MultishotReArmTests.swift
+++ b/Tests/IORingTests/MultishotReArmTests.swift
@@ -1,0 +1,97 @@
+//
+// Copyright (c) 2026 PADL Software Pty Ltd
+//
+// Licensed under the Apache License, Version 2.0 (the License);
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an 'AS IS' BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+
+@preconcurrency import Foundation
+@preconcurrency import Glibc
+@testable import IORing
+import IORingUtils
+import struct SystemPackage.Errno
+import XCTest
+
+final class MultishotReArmTests: XCTestCase {
+  private func makeDatagramPair(ring: IORing) throws -> (rx: Socket, tx: Socket) {
+    var fds = [Int32](repeating: -1, count: 2)
+    guard socketpair(AF_UNIX, Int32(SOCK_DGRAM.rawValue), 0, &fds) == 0 else {
+      throw Errno(rawValue: errno)
+    }
+    let rx = Socket(ring: ring, fileHandle: try FileHandle(fileDescriptor: fds[0], closeOnDealloc: true))
+    let tx = Socket(ring: ring, fileHandle: try FileHandle(fileDescriptor: fds[1], closeOnDealloc: true))
+    return (rx, tx)
+  }
+
+  // A capacity-1 pool plus a send burst reliably provokes -ENOBUFS; the sentinel
+  // must still arrive, proving the multishot re-armed instead of terminating.
+  func testMultishotSurvivesBufferExhaustion() async throws {
+    let ring = try IORing()
+    let (rx, tx) = try makeDatagramPair(ring: ring)
+    let sentinel: UInt8 = 0xFF
+
+    let gotSentinel = try await withThrowingTaskGroup(of: Bool.self) { group in
+      group.addTask {
+        let messages = try await rx.receiveMessages(count: 2048, capacity: 1)
+        for try await message in messages where message.buffer.first == sentinel {
+          return true
+        }
+        return false
+      }
+      group.addTask {
+        try await Task.sleep(nanoseconds: 5_000_000_000)
+        return false
+      }
+      try await Task.sleep(nanoseconds: 50_000_000) // let the receiver arm
+      for _ in 0..<64 { try await tx.send([0x01]) }
+      try await tx.send([sentinel])
+      let result = try await group.next() ?? false
+      group.cancelAll()
+      return result
+    }
+
+    XCTAssertTrue(gotSentinel, "multishot stream did not survive buffer exhaustion")
+  }
+
+  // Sanity: a small (non-default) buffer capacity still delivers a paced stream.
+  func testSmallCapacityDeliversPacedMessages() async throws {
+    let ring = try IORing()
+    let (rx, tx) = try makeDatagramPair(ring: ring)
+    let count = 20
+
+    let received = try await withThrowingTaskGroup(of: Int.self) { group in
+      group.addTask {
+        let messages = try await rx.receiveMessages(count: 2048, capacity: 4)
+        var n = 0
+        for try await _ in messages {
+          n += 1
+          if n == count { return n }
+        }
+        return n
+      }
+      group.addTask {
+        try await Task.sleep(nanoseconds: 5_000_000_000)
+        return -1
+      }
+      try await Task.sleep(nanoseconds: 50_000_000) // let the receiver arm
+      for i in 0..<count {
+        try await tx.send([UInt8(i & 0xff)])
+        try await Task.sleep(nanoseconds: 2_000_000)
+      }
+      let result = try await group.next() ?? -1
+      group.cancelAll()
+      return result
+    }
+
+    XCTAssertEqual(received, count)
+  }
+}


### PR DESCRIPTION
## Problem

A multishot `recvmsg` using a provided-buffer pool terminates with `-ENOBUFS` when the pool is momentarily exhausted under a receive burst (more datagrams ready than free buffers before the async reprovide completes). `Submission.onCompletion` routed that negative `cqe.res` through `throwingErrno` into the `catch`, which called `holder.continuation.finish(throwing:)` — **permanently ending the receive stream**. The re-arm path was only reached for a clean multishot end, never for ENOBUFS.

This bites harder as buffer `capacity` is tuned down (e.g. SwiftMRP's link-local rx sockets), where a small PDU burst can kill rx on a port until the consumer is recreated.

## Change

On `-ENOBUFS`, re-arm the multishot (after a short delay so in-flight buffers are reprovided) rather than finishing the stream. Exhaustion now degrades to dropped overflow frames instead of a dead stream.

## Prototype limitations

- **Fixed 10 ms backoff** — a saturated executor could need longer, yielding 10 ms-paced retries until buffers free.
- **No retry cap.**

A production version should be **reprovision-driven** (re-arm when a buffer is returned) rather than timer-based. Opening as a PR for review on that direction.

## Tests

Adds `MultishotReArmTests`:
- `testMultishotSurvivesBufferExhaustion` — capacity-1 pool + a send burst provokes ENOBUFS; asserts a post-burst sentinel still arrives (stream survived). **Negative control:** with the fix reverted this test fails with `"No buffer space available"`, confirming it's a real regression guard.
- `testSmallCapacityDeliversPacedMessages` — sanity that a small non-default capacity delivers a paced stream.

Full IORing suite: 39/39 pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)